### PR TITLE
allow connecting with HTTPS + prevent "new device" notifications

### DIFF
--- a/plex_auto_languages/__init__.py
+++ b/plex_auto_languages/__init__.py
@@ -1,0 +1,10 @@
+# This prevents the "<user> used a new device to access <server>" notifications from Plex.
+
+import os
+import uuid
+
+os.environ["PLEXAPI_HEADER_IDENTIFIER"] = uuid.uuid3(
+    uuid.NAMESPACE_DNS, "PlexAutoLanguages"
+).hex
+os.environ["PLEXAPI_HEADER_DEVICE_NAME"] = "PlexAutoLanguages"
+os.environ["PLEXAPI_HEADER_PROVIDES"] = ""


### PR DESCRIPTION
This PR allows connecting to a plex server via HTTPS. My implementation doesn't improve security, just allows PAL to work with `Secure connections` set to `Required` in the plex server settings. No SSL cert verification is performed. I figure this is fine in a homelab setting.

A similar problem came up in another project I use ([see here](https://github.com/eliasbenb/PlexAniBridge/pull/110)) so I directly applied that logic to this project for an easy "fix".

Additionally, I noticed that spinning up new PAL containers seems to cause plex unnecessary "New device" notifications which this PR also prevents.