### PR TITLE
fix(alerts): dedupe repeated timeline events so one item can't flood the queue

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from plex_auto_languages.utils.configuration import Configuration
 from plex_auto_languages.utils.healthcheck import HealthcheckServer
 
 # Version information
-__version__ = "1.5.4-dev2"
+__version__ = "1.5.4-dev3"
 
 class PlexAutoLanguages:
     """

--- a/plex_auto_languages/alerts/base.py
+++ b/plex_auto_languages/alerts/base.py
@@ -67,6 +67,25 @@ class PlexAlert:
         """
         return True
 
+    def dedupe_key(self, plex: 'PlexServer'):
+        """Optional key the alert handler uses to collapse a rapid burst of identical
+        alerts before they are queued, so one misbehaving item cannot flood the bounded
+        queue.
+
+        Default ``None`` disables dedup for this alert type. Only **library-level** alert
+        types (whose ``process()`` fans out to all users) whose repeated delivery is
+        redundant may override this. **Per-user** alert types (playing/activity) MUST NOT
+        override it: two users can legitimately produce the same item key, and dropping
+        one would skip that user's track change.
+
+        Args:
+            plex (PlexServer): The Plex server instance (unused by default).
+
+        Returns:
+            A hashable key, or None to never dedupe this alert.
+        """
+        return None
+
     def process(self, plex: 'PlexServer') -> None:
         """
         Process the alert event and perform appropriate actions.

--- a/plex_auto_languages/alerts/timeline.py
+++ b/plex_auto_languages/alerts/timeline.py
@@ -108,6 +108,19 @@ class PlexTimeline(PlexAlert):
             return False
         return True
 
+    def dedupe_key(self, plex: 'PlexServer'):
+        """A single item can emit state=5 timeline events many times per second while
+        Plex repeatedly (re)generates its preview thumbnails / analysis. These are
+        library-level (process() fans out to all users) and process() re-fetches the
+        item's current state, so collapsing a rapid burst of the SAME item to one enqueue
+        per window is safe. The kind (has_metadata_state) is part of the key because
+        'newly added' and 'metadata update' events take different process() branches and
+        must not be collapsed into each other."""
+        try:
+            return (self.item_id, self.has_metadata_state)
+        except (TypeError, ValueError):
+            return None
+
     def process(self, plex: 'PlexServer') -> None:
         """
         Processes the timeline event and triggers appropriate actions.

--- a/plex_auto_languages/plex_alert_handler.py
+++ b/plex_auto_languages/plex_alert_handler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
-from time import sleep
+from time import sleep, monotonic
 import http.client
 from queue import Queue, Empty, Full
 from threading import Thread, Event
@@ -14,6 +14,13 @@ if TYPE_CHECKING:
 
 
 logger = get_logger()
+
+# A single item can re-emit the same timeline event many times per second while Plex
+# regenerates its preview thumbnails / analysis; collapsing repeats of the same dedupe_key
+# within this window keeps one item from flooding the queue. Short enough that legitimately
+# distinct changes are never suppressed (process() re-fetches current state and the cache
+# guards against reprocessing anyway).
+DEDUPE_WINDOW_SECONDS = 5.0
 
 
 class PlexAlertHandler():
@@ -54,6 +61,12 @@ class PlexAlertHandler():
         self._alerts_queue = Queue(maxsize=10000)
         # Single-producer (AlertListener) counter; the stats thread only reads it.
         self._dropped_alerts = 0
+        # Producer-thread-only dedup state: collapse a rapid burst of identical alerts
+        # (same dedupe_key seen within the window) so one misbehaving item cannot flood
+        # the queue. Only the single AlertListener thread touches it, so no lock needed.
+        self._recent_keys = {}
+        self._deduped_alerts = 0
+        self._dedupe_window = DEDUPE_WINDOW_SECONDS
         self._stop_event = Event()
         self._processor_thread = Thread(target=self._process_alerts)
         self._processor_thread.daemon = True
@@ -73,9 +86,33 @@ class PlexAlertHandler():
         """
         while not self._stop_event.wait(300):
             logger.info(
-                "Alert queue depth=%d/%d dropped_total=%d"
+                "Alert queue depth=%d/%d dropped_total=%d deduped_total=%d"
                 % (self._alerts_queue.qsize(), self._alerts_queue.maxsize,
-                   self._dropped_alerts))
+                   self._dropped_alerts, self._deduped_alerts))
+
+    def _is_duplicate(self, alert) -> bool:
+        """Return True if this alert repeats a dedupe_key already seen within the window
+        (a fixed, non-sliding window: the key is re-armed on the first event after each
+        window expires, so a sustained flood still re-enqueues the item once per window
+        and never starves real reprocessing). Runs only on the producer thread."""
+        key = alert.dedupe_key(self._plex)
+        if key is None:
+            return False
+        now = monotonic()
+        last = self._recent_keys.get(key)
+        if last is not None and (now - last) < self._dedupe_window:
+            self._deduped_alerts += 1
+            return True
+        self._recent_keys[key] = now
+        if len(self._recent_keys) > 2048:
+            self._prune_recent_keys(now)
+        return False
+
+    def _prune_recent_keys(self, now: float) -> None:
+        """Drop expired dedup entries so the map stays bounded under a burst of many
+        distinct items (e.g. a large library import)."""
+        cutoff = now - self._dedupe_window
+        self._recent_keys = {k: t for k, t in self._recent_keys.items() if t >= cutoff}
 
     def stop(self) -> None:
         """
@@ -124,6 +161,10 @@ class PlexAlertHandler():
             # activity / status inherit the default (True) so their cache side
             # effects are preserved.
             if not alert.is_relevant(self._plex):
+                continue
+            # Collapse a rapid burst of identical alerts (one item re-emitting the same
+            # event many times per second) before it can flood the bounded queue.
+            if self._is_duplicate(alert):
                 continue
             # Never block the producer (the plexapi AlertListener callback
             # thread): if the consumer is so far behind the bounded queue is


### PR DESCRIPTION
## Problem

#85 bounded the alert queue and pre-filtered the high-frequency `mediaState` / non-library no-op timeline notifications, which stopped the original unbounded-memory leak. But it leaves a **second flood path** uncovered: a **single item** emitting `state=5` "library updated" timeline events faster than the single consumer drains them.

### Measured on a live server

One 4K Dolby Vision movie that Plex was generating preview thumbnails for / analyzing — a genuinely heavy job for a 14 GB 4K-DV file (it ran >70 min, with `session/bif` transcoder procs and the item's `mediaState` cycling `analyzing/thumbnailing/idle`, ~2/sec). I'm not claiming that's a Plex bug — it may just be what a heavy 4K-DV generation looks like — but each of those cycles emits a plain `state=5` timeline event with **no `mediaState`**, so it **passes `is_relevant()` and all of them enqueue**. The single `_process_alerts` consumer does a `fetchItem` per event, so the bounded queue fills with thousands of duplicates of one item (observed depth **9,507/10,000**), and it amplifies a consumer stall: if a fetch is slow, the duplicates pile up behind it.

## Fix

A side-effect-free `dedupe_key()` hook (default `None` on `PlexAlert`; only `PlexTimeline` overrides it → `(itemID, has_metadataState)`). The handler skips enqueue when the same key recurs within a short **fixed 5 s window** (producer-thread-only state, so no lock).

**Why it's safe:**
- Timeline events are **library-level** — `process()` fans out to all users via `process_new_or_updated_episode` — and `process()` re-fetches the item's current state, so collapsing a rapid burst of the same item cannot change which episodes get their tracks set.
- **Per-user** alerts (`PlexPlaying`/`PlexActivity`) keep `dedupe_key=None` and are **never** collapsed — two users playing the same episode share the item key, and dropping one would skip that user's track change.
- `has_metadataState` is part of the key because "newly added" and "metadata update" events take different `process()` branches and must not be collapsed into each other.
- The window is **fixed (not sliding)**, so a sustained flood still re-enqueues the item once per window and never starves real reprocessing; the map is pruned to stay bounded under a burst of distinct items.

## Why not a read timeout

Investigated and deliberately omitted: plexapi already enforces a 30 s read timeout on every query, and the observed stall was a *slow-trickle* response that an inter-byte read timeout cannot catch at any value. The bounded queue (#85) plus this dedup make such a stall non-catastrophic (the queue stays small and the flood self-limits), so no request watchdog is warranted.

## Result (measured before/after on a live deployment)

| | plugin fetch-rate of the item | queue depth |
|---|---|---|
| before | ~2.5 /s | climbed to 200+ |
| after | ~0.1 /s | flat 0 |

Validated with deterministic unit-level repros (1000 identical timeline events → queue depth 1; distinct items and added-vs-update both preserved; per-user playing alerts not collapsed) plus a 5-minute live sustained-flood test on a deployed instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
