### PR TITLE
fix sub force and change detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from plex_auto_languages.utils.configuration import Configuration
 from plex_auto_languages.utils.healthcheck import HealthcheckServer
 
 # Version information
-__version__ = "1.5.4-dev"
+__version__ = "1.5.4-dev2"
 
 class PlexAutoLanguages:
     """

--- a/plex_auto_languages/alerts/playing.py
+++ b/plex_auto_languages/alerts/playing.py
@@ -130,16 +130,39 @@ class PlexPlaying(PlexAlert):
             logger.debug(f"[Play Session] Ignoring show: '{item.show().title}' episode: 'S{item.seasonNumber:02}E{item.episodeNumber:02}' due to file path matching ignore pattern")
             return
 
-        # Skip is the session state is unchanged
+        # Read selected streams before deciding whether this event is a duplicate.
+        # A stream change can happen while the session state remains "playing".
+        item.reload()
+        audio_stream, subtitle_stream = plex.get_selected_streams(item)
+        selected_streams_ids = (
+            audio_stream.id if audio_stream is not None else None,
+            subtitle_stream.id if subtitle_stream is not None else None
+        )
+
+        cached_session_state = None
         if self.session_key in plex.cache.session_states:
             cached_session_data = plex.cache.session_states[self.session_key]
-            if isinstance(cached_session_data, tuple) and cached_session_data[0] == self.session_state:
-                return
-            elif not isinstance(cached_session_data, tuple) and cached_session_data == self.session_state:
-                return
-        logger.debug(f"[Play Session] "
-                     f"Session: {self.session_key} | State: '{self.session_state}' | User id: {user_id} | Episode: {item}")
+            if isinstance(cached_session_data, tuple):
+                cached_session_state = cached_session_data[0]
+            else:
+                cached_session_state = cached_session_data
+
+        cached_streams_ids = plex.cache.default_streams.get(item.key)
+
+        # Skip only if both the session state and selected streams are unchanged.
+        if cached_session_state == self.session_state and cached_streams_ids == selected_streams_ids:
+            return
+
+        logger.debug(
+            f"[Play Session] Session: {self.session_key} | "
+            f"State: '{self.session_state}' | "
+            f"User id: {user_id} | "
+            f"Episode: {item} | "
+            f"Streams: {selected_streams_ids}"
+        )
+
         plex.cache.session_states[self.session_key] = (self.session_state, datetime.now())
+        plex.cache.default_streams[item.key] = selected_streams_ids
 
         # Reset cache if the session is stopped
         if self.session_state == "stopped":
@@ -148,17 +171,7 @@ class PlexPlaying(PlexAlert):
                 del plex.cache.session_states[self.session_key]
             if self.client_identifier in plex.cache.user_clients:
                 del plex.cache.user_clients[self.client_identifier]
-
-        # Skip if selected streams are unchanged
-        item.reload()
-        audio_stream, subtitle_stream = plex.get_selected_streams(item)
-        selected_streams_ids = (
-            audio_stream.id if audio_stream is not None else None,
-            subtitle_stream.id if subtitle_stream is not None else None
-        )
-        if item.key in plex.cache.default_streams and plex.cache.default_streams[item.key] == selected_streams_ids:
             return
-        plex.cache.default_streams[item.key] = selected_streams_ids
 
         # Limit the size of default_streams to prevent memory leak
         if len(plex.cache.default_streams) > 10000:

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -185,11 +185,15 @@ class TrackChanges():
                 # If no matching subtitle found, only reset to None when the reference had NO subtitle selected.
                 if current_subtitle_stream is not None and matching_subtitle_stream is None:
                     if self._subtitle_stream is None:
-                        # reference explicitly has subtitles off -> clear current subtitle
+                        # Reference explicitly has subtitles off -> clear current subtitle.
+                        self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
+                    elif self.is_forced_subtitle(self._subtitle_stream):
+                        # Reference uses forced subtitles, but this part has no matching forced subtitle.
+                        # Clear the current subtitle instead of keeping a regular subtitle from the same language.
                         self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
                     else:
-                        # reference had a subtitle but we couldn't find a matching one for this part.
-                        # Do not clear — leave the user's current setting in place.
+                        # Reference had a regular subtitle but no matching subtitle was found for this part.
+                        # Keep the current subtitle to avoid disabling subtitles unexpectedly.
                         pass
 
                 if matching_subtitle_stream is not None and \
@@ -409,6 +413,25 @@ class TrackChanges():
         logger.debug(f"[Language Update] Audio scores: {score_str}")
         return streams[scores.index(max(scores))]
 
+    def is_forced_subtitle(self, stream: SubtitleStream) -> bool:
+        title = getattr(stream, "title", None)
+        display_title = getattr(stream, "displayTitle", None)
+        extended_display_title = getattr(stream, "extendedDisplayTitle", None)
+        forced_flag = bool(getattr(stream, "forced", False))
+    
+        searchable_text = " ".join([
+            title or "",
+            display_title or "",
+            extended_display_title or "",
+        ]).lower()
+    
+        forced_from_title = (
+            "forced" in searchable_text
+        )
+    
+        result = forced_flag or forced_from_title
+        return result
+        
     def _match_subtitle_stream(self, subtitle_streams: List[SubtitleStream]) -> Optional[SubtitleStream]:
         """
         Find the best matching subtitle stream from a list of available streams.
@@ -430,14 +453,14 @@ class TrackChanges():
             match_hearing_impaired_only = False
             language_code = self._audio_stream.languageCode
         else:
-            match_forced_only = self._subtitle_stream.forced
+            match_forced_only = self.is_forced_subtitle(self._subtitle_stream)
             match_hearing_impaired_only = self._subtitle_stream.hearingImpaired
             language_code = self._subtitle_stream.languageCode
 
         # We only want streams with the same language code
         streams = [s for s in subtitle_streams if s.languageCode == language_code]
         if match_forced_only:
-            streams = [s for s in streams if s.forced]
+            streams = [s for s in streams if self.is_forced_subtitle(s)]
         if match_hearing_impaired_only:
             streams = [s for s in streams if s.hearingImpaired]
 
@@ -451,7 +474,7 @@ class TrackChanges():
         scores = [0] * len(streams)
         for index, stream in enumerate(streams):
             if self._subtitle_stream is not None:
-                if self._subtitle_stream.forced == stream.forced:
+                if self.is_forced_subtitle(self._subtitle_stream) == self.is_forced_subtitle(stream):
                     scores[index] += 3
                 if self._subtitle_stream.hearingImpaired == stream.hearingImpaired:
                     scores[index] += 3


### PR DESCRIPTION
- Fixed: the detection of forced subtitles (now subtitles containing the word "forced" will be considered forced).
- Fixed: When a forced subtitle track is selected but some episodes do not contain that track, the subtitles are now set to "none".
- Fixed: Language and subtitle switching during playback has been improved so that the change takes effect immediately.