### PR TITLE
(re open)add option subtitle_none_behavior for choose the behavior when subs are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,17 +179,21 @@ plex:
 
 ```yaml
 plexautolanguages:
-  update_level: "show"          # Options: "show" (default), "season"
-  update_strategy: "next"       # Options: "all", "next" (default)
-  trigger_on_play: true         # Update language when playing an episode
-  trigger_on_scan: true         # Update language when new files are scanned
-  trigger_on_activity: false    # Update language when navigating Plex (experimental)
-  refresh_library_on_scan: true # Refresh cached library on Plex scans
-  ignore_labels:                # Ignore shows with these Plex labels
+  update_level: "show"              # Options: "show" (default), "season"
+  update_strategy: "next"           # Options: "all", "next" (default)
+  trigger_on_play: true             # Update language when playing an episode
+  trigger_on_scan: true             # Update language when new files are scanned
+  trigger_on_activity: false        # Update language when navigating Plex (experimental)
+  refresh_library_on_scan: true     # Refresh cached library on Plex scans
+  subtitle_none_behavior: "forced"  # Options: "forced" (default), "disabled"
+                                    # "forced": when no subtitle is selected, PAL will try to apply forced subtitles matching the audio language
+                                    # "disabled": when no subtitle is selected, PAL will disable subtitles completely
+
+  ignore_labels:                    # Ignore shows with these Plex labels
     - PAL_IGNORE
-  ignore_libraries:             # Ignore these libraries when updating sub/audio language
+  ignore_libraries:                 # Ignore these libraries when updating sub/audio language
     - ""
-  ignore_filepatterns:          # Ignore episodes whose media file path matches these regex patterns
+  ignore_filepatterns:              # Ignore episodes whose media file path matches these regex patterns
     - ""
 ```
 
@@ -216,26 +220,27 @@ debug: false   # Enable debug logs
 
 ### Environment Variable Summary
 
-| Environment Variable            | Default Value | Description                                                                                                                  |
-| ------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `PLEX_URL`                      | *(none)*      | URL to your Plex server. Replace `http://plex:32400` with your actual Plex server URL.                                       |
-| `PLEX_TOKEN`                    | *(none)*      | Plex authentication token.                                                                                                   |
-| `PLEX_CONNECTION_MAX_RETRIES`   | `300`         | Maximum number of connection attempts when connecting to the Plex server.                                                    |
-| `PLEX_CONNECTION_RETRY_DELAY`   | `5`           | Delay in seconds between connection retry attempts.                                                                          |
-| `UPDATE_LEVEL`                  | `show`        | Determines whether the update applies to the entire show or just the current season. Accepted values: `show`, `season`.      |
-| `UPDATE_STRATEGY`               | `next`        | Chooses whether to update all episodes or only the next one. Accepted values: `all`, `next`.                                 |
-| `TRIGGER_ON_PLAY`               | `true`        | If set to true, playing an episode triggers a language update.                                                               |
-| `TRIGGER_ON_SCAN`               | `true`        | If set to true, scanning for new files triggers a language update.                                                           |
-| `TRIGGER_ON_ACTIVITY`           | `false`       | If set to true, browsing the Plex library triggers a language update.                                                        |
-| `REFRESH_LIBRARY_ON_SCAN`       | `true`        | Refreshes the cached library when the Plex server scans its library.                                                         |
-| `IGNORE_LABELS`                 | `PAL_IGNORE`  | Comma-separated list of Plex labels. Shows with these labels will be ignored.                                                |
-| `IGNORE_LIBRARIES`              | *(none)*      | Comma-separated list of library names that PAL will ignore when updating subtitle/audio languages.                           |
-| `IGNORE_FILEPATTERNS`           | *(none)*      | Comma-separated list of regex patterns matched against media file paths. Episodes with matching files are ignored (e.g. `.*coming\.soon.*,.*trailer.*`). |
-| `SCHEDULER_ENABLE`              | `true`        | Enables or disables the scheduler feature.                                                                                   |
-| `SCHEDULER_SCHEDULE_TIME`       | `02:00`       | Time (in `HH:MM` format) when the scheduler starts its task.                                                                 |
-| `NOTIFICATIONS_ENABLE`          | `false`       | Enables or disables notifications.                                                                                           |
-| `NOTIFICATIONS_APPRISE_CONFIGS` | `[]`          | JSON array of Apprise notification configurations. See Apprise docs for more information: https://github.com/caronc/apprise. |
-| `DEBUG`                         | `false`       | Enables debug mode for verbose logging.                                                                                      |
+| Environment Variable            | Default Value | Description                                                                                                                                                                                                                          |
+| ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PLEX_URL`                      | *(none)*      | URL to your Plex server. Replace `http://plex:32400` with your actual Plex server URL.                                                                                                                                               |
+| `PLEX_TOKEN`                    | *(none)*      | Plex authentication token.                                                                                                                                                                                                           |
+| `PLEX_CONNECTION_MAX_RETRIES`   | `300`         | Maximum number of connection attempts when connecting to the Plex server.                                                                                                                                                            |
+| `PLEX_CONNECTION_RETRY_DELAY`   | `5`           | Delay in seconds between connection retry attempts.                                                                                                                                                                                  |
+| `UPDATE_LEVEL`                  | `show`        | Determines whether the update applies to the entire show or just the current season. Accepted values: `show`, `season`.                                                                                                              |
+| `UPDATE_STRATEGY`               | `next`        | Chooses whether to update all episodes or only the next one. Accepted values: `all`, `next`.                                                                                                                                         |
+| `TRIGGER_ON_PLAY`               | `true`        | If set to true, playing an episode triggers a language update.                                                                                                                                                                       |
+| `TRIGGER_ON_SCAN`               | `true`        | If set to true, scanning for new files triggers a language update.                                                                                                                                                                   |
+| `TRIGGER_ON_ACTIVITY`           | `false`       | If set to true, browsing the Plex library triggers a language update.                                                                                                                                                                |
+| `REFRESH_LIBRARY_ON_SCAN`       | `true`        | Refreshes the cached library when the Plex server scans its library.                                                                                                                                                                 |
+| `SUBTITLE_NONE_BEHAVIOR`        | `forced`      | Controls what PAL does when no subtitle is selected on the reference episode. Accepted values: `forced`, `disabled`. `forced` tries to apply forced subtitles matching the audio language; `disabled` disables subtitles completely. |
+| `IGNORE_LABELS`                 | `PAL_IGNORE`  | Comma-separated list of Plex labels. Shows with these labels will be ignored.                                                                                                                                                        |
+| `IGNORE_LIBRARIES`              | *(none)*      | Comma-separated list of library names that PAL will ignore when updating subtitle/audio languages.                                                                                                                                   |
+| `IGNORE_FILEPATTERNS`           | *(none)*      | Comma-separated list of regex patterns matched against media file paths. Episodes with matching files are ignored (e.g. `.*coming\.soon.*,.*trailer.*`).                                                                             |
+| `SCHEDULER_ENABLE`              | `true`        | Enables or disables the scheduler feature.                                                                                                                                                                                           |
+| `SCHEDULER_SCHEDULE_TIME`       | `02:00`       | Time (in `HH:MM` format) when the scheduler starts its task.                                                                                                                                                                         |
+| `NOTIFICATIONS_ENABLE`          | `false`       | Enables or disables notifications.                                                                                                                                                                                                   |
+| `NOTIFICATIONS_APPRISE_CONFIGS` | `[]`          | JSON array of Apprise notification configurations. See Apprise docs for more information: https://github.com/caronc/apprise.                                                                                                         |
+| `DEBUG`                         | `false`       | Enables debug mode for verbose logging.                                                                                                                                                                                              |
 
 > [!NOTE]
 >

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,10 @@ plexautolanguages:
   # Disabling this parameter will prevent PlexAutoLanguages from detecting updated files for an already existing episode
   # It is recommended to disable this parameter if you have a large TV Show library (10k+ episodes)
   refresh_library_on_scan: true
+  
+  # "forced"  => comportement actuel : si aucun sous-titre est choisi, chercher les sous-titres forced
+  # "disabled" => vrai aucun sous-titre : désactiver tous les sous-titres
+  subtitle_none_behavior: "forced"
 
   # PlexAutoLanguages will ignore shows with any of the following Plex labels
   ignore_labels:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -5,6 +5,7 @@ plexautolanguages:
   trigger_on_scan: true
   trigger_on_activity: false
   refresh_library_on_scan: true
+  subtitle_none_behavior: "forced"
   ignore_labels:
     - PAL_IGNORE
   ignore_libraries:

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from plex_auto_languages.utils.configuration import Configuration
 from plex_auto_languages.utils.healthcheck import HealthcheckServer
 
 # Version information
-__version__ = "1.5.4-dev"
+__version__ = "1.5.4-dev2"
 
 class PlexAutoLanguages:
     """

--- a/plex_auto_languages/plex_server.py
+++ b/plex_auto_languages/plex_server.py
@@ -672,7 +672,7 @@ class PlexServer(UnprivilegedPlexServer):
             episode (Episode): The episode to modify.
             event_type (EventType): The type of event that triggered this change.
         """
-        track_changes = TrackChanges(username, episode, event_type)
+        track_changes = TrackChanges(username, episode, event_type, self.config.get("subtitle_none_behavior"))
         # Get episodes to update
         episodes = track_changes.get_episodes_to_update(self.config.get("update_level"), self.config.get("update_strategy"))
 

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -28,7 +28,7 @@ class TrackChanges():
         _computed (bool): Whether changes have been computed.
     """
 
-    def __init__(self, username: str, reference: Episode, event_type: EventType):
+    def __init__(self, username: str, reference: Episode, event_type: EventType, subtitle_none_behavior: str):
         """
         Initialize a TrackChanges instance.
 
@@ -40,6 +40,7 @@ class TrackChanges():
         self._reference = reference
         self._username = username
         self._event_type = event_type
+        self._subtitle_none_behavior = subtitle_none_behavior
         self._audio_stream, self._subtitle_stream = self._get_selected_streams(reference)
         self._changes = []
         self._description = ""
@@ -449,6 +450,8 @@ class TrackChanges():
         if self._subtitle_stream is None:
             if self._audio_stream is None:
                 return None
+            if self._subtitle_none_behavior == "disabled":
+                return None
             match_forced_only = True
             match_hearing_impaired_only = False
             language_code = self._audio_stream.languageCode
@@ -461,6 +464,8 @@ class TrackChanges():
         streams = [s for s in subtitle_streams if s.languageCode == language_code]
         if match_forced_only:
             streams = [s for s in streams if self.is_forced_subtitle(s)]
+        else:
+            streams = [s for s in streams if not self.is_forced_subtitle(s)]
         if match_hearing_impaired_only:
             streams = [s for s in streams if s.hearingImpaired]
 
@@ -476,6 +481,8 @@ class TrackChanges():
             if self._subtitle_stream is not None:
                 if self.is_forced_subtitle(self._subtitle_stream) == self.is_forced_subtitle(stream):
                     scores[index] += 3
+                else:
+                    scores[index] -= 10
                 if self._subtitle_stream.hearingImpaired == stream.hearingImpaired:
                     scores[index] += 3
                 if self._subtitle_stream.codec is not None and stream.codec is not None and \
@@ -621,7 +628,7 @@ class NewOrUpdatedTrackChanges():
             episode (Episode): The episode to apply changes to.
         """
         self._episode = episode
-        track_changes = TrackChanges(username, reference, self._event_type)
+        track_changes = TrackChanges(username, reference, self._event_type, plex.config.subtitle_none_behavior)
         track_changes.compute([episode])
         changes_were_made = track_changes.has_changes
         track_changes.apply()

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -464,8 +464,6 @@ class TrackChanges():
         streams = [s for s in subtitle_streams if s.languageCode == language_code]
         if match_forced_only:
             streams = [s for s in streams if self.is_forced_subtitle(s)]
-        else:
-            streams = [s for s in streams if not self.is_forced_subtitle(s)]
         if match_hearing_impaired_only:
             streams = [s for s in streams if s.hearingImpaired]
 
@@ -481,8 +479,6 @@ class TrackChanges():
             if self._subtitle_stream is not None:
                 if self.is_forced_subtitle(self._subtitle_stream) == self.is_forced_subtitle(stream):
                     scores[index] += 3
-                else:
-                    scores[index] -= 10
                 if self._subtitle_stream.hearingImpaired == stream.hearingImpaired:
                     scores[index] += 3
                 if self._subtitle_stream.codec is not None and stream.codec is not None and \

--- a/plex_auto_languages/utils/configuration.py
+++ b/plex_auto_languages/utils/configuration.py
@@ -278,6 +278,9 @@ class Configuration:
         if self.get("update_strategy") not in ["all", "next"]:
             logger.error("The 'update_strategy' parameter must be either 'all' or 'next'")
             raise InvalidConfiguration
+        if self.get("subtitle_none_behavior") not in ["forced", "disabled"]:
+            logger.error("The 'subtitle_none_behavior' parameter must be either 'forced' or 'disabled'")
+            raise InvalidConfiguration
         if not isinstance(self.get("ignore_labels"), list):
             logger.error("The 'ignore_labels' parameter must be a list or a string-based comma separated list")
             raise InvalidConfiguration


### PR DESCRIPTION
2 values possible:

forced: current behavior (reactivates forced subs)
disabled: to turn off subtitles for all episodes of the series/season...

i'm reopening this PR because I moved it to a separate branch.
old pr : https://github.com/JourneyDocker/Plex-Auto-Languages/pull/92

In summary, the parameter value defines:

whether forced subtitles are selected by default when subtitles are disabled

If subtitles are disabled, select "no subtitles" for each episode