### PR TITLE
Improve audio/subtitle propagation when episodes have different streams

### DIFF
--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -239,9 +239,9 @@ class TrackChanges():
                 # If the reference episode has no subtitle streams at all, do not propagate "None" to other episodes.
                 # This avoids disabling subtitles on episodes that do have subtitle streams while the reference episode
                 # simply has burned-in subtitles or no subtitle track available.
-                if current_subtitle_stream is not None and matching_subtitle_stream is None:
+                if matching_subtitle_stream is None:
                     if self._subtitle_stream is None:
-                        if reference_has_subtitle_streams:
+                        if current_subtitle_stream is not None and reference_has_subtitle_streams:
                             # Reference has subtitle streams and subtitles are explicitly off -> clear current subtitle.
                             self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
                         else:
@@ -249,8 +249,20 @@ class TrackChanges():
                             pass
                     elif self.is_forced_subtitle(self._subtitle_stream):
                         # Reference uses forced subtitles, but this part has no matching forced subtitle.
-                        # Clear the current subtitle instead of keeping a regular subtitle from the same language.
-                        self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
+                        # Try to fall back to a regular subtitle with the same language before disabling subtitles.
+                        fallback_subtitle_stream = self._match_regular_subtitle_stream_by_language(
+                            part.subtitleStreams(),
+                            self._subtitle_stream.languageCode
+                        )
+
+                        if fallback_subtitle_stream is not None:
+                            if current_subtitle_stream is None or fallback_subtitle_stream.id != current_subtitle_stream.id:
+                                self._changes.append((episode, part, SubtitleStream.STREAMTYPE, fallback_subtitle_stream))
+                                logger.debug(f"[Language Update] Applying regular subtitle fallback for show '{episode.show().title}' "
+                                             f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                             f"and user '{self.username}' because no matching forced subtitle was found")
+                        elif current_subtitle_stream is not None:
+                            self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
                     else:
                         # Reference had a regular subtitle but no matching subtitle was found for this part.
                         # Keep the current subtitle to avoid disabling subtitles unexpectedly.

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -171,15 +171,67 @@ class TrackChanges():
                      f"and user '{self._username}' based on episode: 'S{self._reference.seasonNumber:02}E{self._reference.episodeNumber:02}'")
         self._changes = []
         reference_has_subtitle_streams = len(self._reference.subtitleStreams()) > 0
+        reference_audio_stream_count = len(self._reference.audioStreams())
+
         for episode in episodes:
             episode.reload()
             for part in episode.iterParts():
                 current_audio_stream, current_subtitle_stream = self._get_selected_streams(part)
+                audio_streams = part.audioStreams()
+
                 # Audio stream
-                matching_audio_stream = self._match_audio_stream(part.audioStreams())
-                if current_audio_stream is not None and matching_audio_stream is not None and \
-                        matching_audio_stream.id != current_audio_stream.id:
-                    self._changes.append((episode, part, AudioStream.STREAMTYPE, matching_audio_stream))
+                matching_audio_stream = self._match_audio_stream(audio_streams)
+
+                # If the reference audio stream cannot be matched on this part, do not apply
+                # the reference subtitle directly. However, if the reference has no subtitle selected,
+                # try to fall back to a regular subtitle matching the reference audio language.
+                #
+                # Example:
+                # Reference: FR audio + no subtitles
+                # Target: JP audio only + FR subtitles
+                # Result: keep JP audio and select regular FR subtitles.
+                if self._audio_stream is not None and matching_audio_stream is None:
+                    if self._subtitle_stream is None:
+                        fallback_subtitle_stream = self._match_regular_subtitle_stream_by_language(
+                            part.subtitleStreams(),
+                            self._audio_stream.languageCode
+                        )
+
+                        if fallback_subtitle_stream is not None and \
+                                (current_subtitle_stream is None or fallback_subtitle_stream.id != current_subtitle_stream.id):
+                            self._changes.append((episode, part, SubtitleStream.STREAMTYPE, fallback_subtitle_stream))
+                            logger.debug(f"[Language Update] Applying fallback subtitle for show '{episode.show().title}' "
+                                         f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                         f"and user '{self.username}' because no matching audio stream was found")
+                        else:
+                            logger.debug(f"[Language Update] Skipping subtitle changes for show '{episode.show().title}' "
+                                         f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                         f"and user '{self.username}' because no matching audio stream or fallback subtitle was found")
+                    else:
+                        logger.debug(f"[Language Update] Skipping subtitle changes for show '{episode.show().title}' "
+                                     f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                     f"and user '{self.username}' because no matching audio stream was found")
+                    continue
+
+                reference_has_single_audio = self._audio_stream is not None and reference_audio_stream_count == 1
+                target_has_multiple_audio = len(audio_streams) > 1
+                weak_reference_audio = reference_has_single_audio and target_has_multiple_audio
+
+                if weak_reference_audio:
+                    # The reference has only one audio stream while the target has multiple audio streams.
+                    # Do not propagate the audio stream itself, because a single available audio stream can simply be Plex's fallback.
+                    # However, subtitle changes are still allowed if the target is already using the same audio language.
+                    if current_audio_stream is None or current_audio_stream.languageCode != self._audio_stream.languageCode:
+                        logger.debug(f"[Language Update] Skipping language changes for show '{episode.show().title}' "
+                                     f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                     f"and user '{self.username}' because the reference has only one audio stream "
+                                     f"and the target is not currently using the same audio language")
+                        continue
+                else:
+                    if current_audio_stream is not None and matching_audio_stream is not None and \
+                            matching_audio_stream.id != current_audio_stream.id:
+                        self._changes.append((episode, part, AudioStream.STREAMTYPE, matching_audio_stream))
+
                 # Subtitle stream
                 matching_subtitle_stream = self._match_subtitle_stream(part.subtitleStreams())
 
@@ -187,7 +239,6 @@ class TrackChanges():
                 # If the reference episode has no subtitle streams at all, do not propagate "None" to other episodes.
                 # This avoids disabling subtitles on episodes that do have subtitle streams while the reference episode
                 # simply has burned-in subtitles or no subtitle track available.
-                
                 if current_subtitle_stream is not None and matching_subtitle_stream is None:
                     if self._subtitle_stream is None:
                         if reference_has_subtitle_streams:
@@ -207,16 +258,60 @@ class TrackChanges():
 
                 if matching_subtitle_stream is not None and \
                         (current_subtitle_stream is None or matching_subtitle_stream.id != current_subtitle_stream.id):
-                    if current_audio_stream is not None and current_audio_stream.title is not None and \
-                            "commentary" in current_audio_stream.title.lower() and matching_audio_stream is None:
-                        # if the changed stream was commentary but this ep has none, then don't touch subs
-                        logger.debug(f"[Language Update] Skipping subtitle changes for show '{episode.show().title}' "
-                                     f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
-                                     f"and user '{self.username}'")
-                    else:
-                        self._changes.append((episode, part, SubtitleStream.STREAMTYPE, matching_subtitle_stream))
+                    self._changes.append((episode, part, SubtitleStream.STREAMTYPE, matching_subtitle_stream))
+
         self._update_description(episodes)
         self._computed = True
+
+    def _match_regular_subtitle_stream_by_language(
+            self,
+            subtitle_streams: List[SubtitleStream],
+            language_code: str
+    ) -> Optional[SubtitleStream]:
+        """
+        Find a regular non-forced subtitle stream matching the given language code.
+
+        This is used as a fallback when the reference audio language cannot be applied
+        to the target episode and the reference has no subtitle selected.
+        """
+        if language_code is None:
+            return None
+
+        streams = [
+            s for s in subtitle_streams
+            if s.languageCode == language_code and not self.is_forced_subtitle(s)
+        ]
+
+        if len(streams) == 0:
+            return None
+
+        non_hearing_impaired_streams = [
+            s for s in streams
+            if not getattr(s, "hearingImpaired", False)
+        ]
+        if len(non_hearing_impaired_streams) > 0:
+            streams = non_hearing_impaired_streams
+
+        if len(streams) == 1:
+            return streams[0]
+
+        scores = [0] * len(streams)
+        for index, stream in enumerate(streams):
+            if stream.codec is not None:
+                scores[index] += 1
+            if stream.extendedDisplayTitle is not None:
+                scores[index] += 1
+            if stream.displayTitle is not None:
+                scores[index] += 1
+            if stream.title is not None:
+                scores[index] += 1
+
+        score_str = ", ".join(
+            f"{(stream.extendedDisplayTitle or stream.title or 'Unknown')}={score}"
+            for stream, score in zip(streams, scores)
+        )
+        logger.debug(f"[Language Update] Fallback subtitle scores: {score_str}")
+        return streams[scores.index(max(scores))]
 
     def apply(self) -> None:
         """

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -182,6 +182,12 @@ class TrackChanges():
                 # Audio stream
                 matching_audio_stream = self._match_audio_stream(audio_streams)
 
+                current_audio_is_commentary = (
+                    current_audio_stream is not None and
+                    current_audio_stream.title is not None and
+                    "commentary" in current_audio_stream.title.lower()
+                )
+
                 # If the reference audio stream cannot be matched on this part, do not apply
                 # the reference subtitle directly. However, if the reference has no subtitle selected,
                 # try to fall back to a regular subtitle matching the reference audio language.
@@ -191,7 +197,12 @@ class TrackChanges():
                 # Target: JP audio only + FR subtitles
                 # Result: keep JP audio and select regular FR subtitles.
                 if self._audio_stream is not None and matching_audio_stream is None:
-                    if self._subtitle_stream is None:
+                    if current_audio_is_commentary:
+                        logger.debug(f"[Language Update] Skipping subtitle changes for show '{episode.show().title}' "
+                                     f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                     f"and user '{self.username}' because the current audio stream is commentary "
+                                     f"and no matching audio stream was found")
+                    elif self._subtitle_stream is None:
                         fallback_subtitle_stream = self._match_regular_subtitle_stream_by_language(
                             part.subtitleStreams(),
                             self._audio_stream.languageCode

--- a/plex_auto_languages/track_changes.py
+++ b/plex_auto_languages/track_changes.py
@@ -249,18 +249,32 @@ class TrackChanges():
                             pass
                     elif self.is_forced_subtitle(self._subtitle_stream):
                         # Reference uses forced subtitles, but this part has no matching forced subtitle.
-                        # Try to fall back to a regular subtitle with the same language before disabling subtitles.
-                        fallback_subtitle_stream = self._match_regular_subtitle_stream_by_language(
-                            part.subtitleStreams(),
-                            self._subtitle_stream.languageCode
+                        # If audio and subtitle languages are different, fall back to a regular subtitle
+                        # in the same subtitle language. If they are the same language, disabling subtitles
+                        # is more natural than selecting a full regular subtitle.
+                        audio_language_code = self._audio_stream.languageCode if self._audio_stream is not None else None
+                        subtitle_language_code = self._subtitle_stream.languageCode
+
+                        should_try_regular_fallback = (
+                            audio_language_code is not None and
+                            subtitle_language_code is not None and
+                            audio_language_code != subtitle_language_code
                         )
 
-                        if fallback_subtitle_stream is not None:
-                            if current_subtitle_stream is None or fallback_subtitle_stream.id != current_subtitle_stream.id:
-                                self._changes.append((episode, part, SubtitleStream.STREAMTYPE, fallback_subtitle_stream))
-                                logger.debug(f"[Language Update] Applying regular subtitle fallback for show '{episode.show().title}' "
-                                             f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
-                                             f"and user '{self.username}' because no matching forced subtitle was found")
+                        if should_try_regular_fallback:
+                            fallback_subtitle_stream = self._match_regular_subtitle_stream_by_language(
+                                part.subtitleStreams(),
+                                subtitle_language_code
+                            )
+
+                            if fallback_subtitle_stream is not None:
+                                if current_subtitle_stream is None or fallback_subtitle_stream.id != current_subtitle_stream.id:
+                                    self._changes.append((episode, part, SubtitleStream.STREAMTYPE, fallback_subtitle_stream))
+                                    logger.debug(f"[Language Update] Applying regular subtitle fallback for show '{episode.show().title}' "
+                                                 f"episode 'S{episode.seasonNumber:02}E{episode.episodeNumber:02}' "
+                                                 f"and user '{self.username}' because no matching forced subtitle was found")
+                            elif current_subtitle_stream is not None:
+                                self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
                         elif current_subtitle_stream is not None:
                             self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
                     else:


### PR DESCRIPTION
## Context

This pull request improves the audio and subtitle propagation logic in Plex-Auto-Languages to better handle TV shows where episodes do not all expose the exact same audio and subtitle streams.

Currently, PAL propagates the selected tracks from a reference episode. This works well when all episodes have the same audio and subtitle streams, but it can produce unnatural results when some episodes have fewer audio tracks, fewer subtitles, or missing `forced` subtitle tracks.

The goal of this change is to preserve Plex’s natural behavior as much as possible, while avoiding inconsistent combinations such as:

```text
Japanese audio + Japanese subtitles
even though the requested French audio does not exist on the target episode
```

or:

```text
Subtitles disabled
even though a full subtitle track in the expected language exists and would be a better fallback
```

## Identified issues

### 1. Propagating `None` from an episode with no subtitle streams

Some episodes may have burned-in subtitles and therefore contain no subtitle stream that Plex can select.

In that case, the reference episode may be played with:

```text
Subtitles: None
```

But this does not necessarily mean the user wants to disable subtitles for the whole show. It may simply mean that the episode has no subtitle stream available.

Example:

```text
Episode 1:
Audio: Chinese
Subtitles: no available subtitle stream
Subtitles are burned into the video

Episode 2:
Audio: Chinese
Subtitles: French
No burned-in subtitles
```

Before:

```text
PAL could propagate "None" to episode 2.
Result: episode 2 stayed without subtitles, even though a French subtitle track was available.
```

After:

```text
If the reference episode has no subtitle streams at all, PAL does not propagate "None" to other episodes.
```

## 2. Reference audio missing on the target episode

Another issue happens when the selected audio stream on the reference episode does not exist on another episode.

Example:

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: Japanese
Subtitles: French
```

If the user selects on episode 1:

```text
Audio: French
Subtitles: French forced
```

Episode 2 does not have French audio.

Before:

```text
PAL could still apply the subtitle logic.
If the French forced subtitle did not exist on episode 2, PAL could disable subtitles.
```

Unnatural result:

```text
Episode 2:
Audio: Japanese
Subtitles: None
```

After:

```text
If the reference audio does not exist on the target episode, PAL does not directly apply the selected reference subtitle.
```

This avoids applying a subtitle choice that belongs to an audio stream that could not be applied.

## 3. Natural fallback when the reference audio is missing and the reference has no subtitle selected

However, there is one case where doing nothing is not enough.

Example:

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: Japanese
Subtitles: French
```

User sequence:

```text
1. The user plays episode 1 in Japanese.
2. The user disables subtitles.
3. Episode 2 naturally switches to Japanese with no subtitles.

Then:

4. The user switches episode 1 back to French.
5. Subtitles remain disabled.
```

Episode 2 does not have French audio, but it does have French subtitles.

Expected natural behavior:

```text
Episode 2:
Audio: Japanese
Subtitles: French
```

Reason:

```text
The requested French audio does not exist on episode 2.
The closest natural equivalent is to keep the available audio and use a full French subtitle track.
```

This change therefore adds a specific fallback:

```text
If the reference audio is missing on the target episode
AND the reference has no subtitle selected
THEN look for a regular subtitle track matching the reference audio language.
```

Example:

```text
Reference:
Audio: French
Subtitles: None

Target:
Audio: Japanese only
Subtitles: French

Result:
Audio: Japanese
Subtitles: French
```

This fallback only uses non-forced subtitle tracks.

## 4. Reference with a single audio stream applied to a multi-audio target

A selected audio stream on an episode that only has one audio stream is not necessarily a strong user preference. It may simply be the only available stream.

Example:

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: Japanese
Subtitles: French
```

If the user plays episode 2:

```text
Audio: Japanese
Subtitles: French
```

Before:

```text
PAL could propagate this selection to episode 1.
```

But on episode 2, Japanese audio was not necessarily an explicit user choice: it was the only available audio stream.

After:

```text
If the reference episode has only one audio stream
AND the target episode has multiple audio streams,
PAL does not change the target episode audio.
```

However, subtitles may still be applied if the target episode is already using the same audio language as the reference.

Allowed example:

```text
Reference episode:
Audio: French only
Subtitles: French non-forced

Target episode:
Audio: French, English
Currently selected audio: French
Subtitles: French forced, French, English

Result:
PAL may select the French non-forced subtitle on the target episode.
PAL does not modify the audio.
```

Blocked example:

```text
Reference episode:
Audio: Japanese only
Subtitles: French

Target episode:
Audio: French, Japanese
Currently selected audio: French

Result:
PAL does not modify either audio or subtitles.
```

## 5. Forced subtitle handling

The forced subtitle logic must remain the priority when a matching forced subtitle exists on the target episode.

Example:

```text
Reference episode:
Audio: French
Subtitles: French forced

Target episode:
Audio: French
Subtitles: French forced, French
```

Expected result:

```text
PAL selects French forced.
```

This logic remains unchanged: if the matching forced subtitle exists, it is selected.

## 6. Missing forced subtitle: fallback or disable depending on the audio language

The most subtle case is when the forced subtitle selected on the reference episode does not exist on the target episode.

Two situations must be handled differently.

### Case A: audio and forced subtitle are in different languages

Example:

```text
Reference episode:
Audio: Japanese
Subtitles: French forced

Target episode:
Audio: Japanese
Subtitles: French
```

The `French forced` subtitle does not exist on the target episode, but a full French subtitle exists.

Expected behavior:

```text
PAL uses the regular French subtitle as a fallback.
```

Reason:

```text
The audio is Japanese.
The French forced subtitle was probably used to translate required parts.
If the forced subtitle does not exist, the full French subtitle is a better fallback than no subtitles.
```

Result:

```text
Target episode:
Audio: Japanese
Subtitles: French
```

### Case B: audio and forced subtitle are in the same language

Example:

```text
Reference episode:
Audio: French
Subtitles: French forced

Target episode:
Audio: French
Subtitles: French
```

The `French forced` subtitle does not exist on the target episode, but a full French subtitle exists.

Expected behavior:

```text
PAL should not select the full French subtitle.
PAL should disable subtitles.
```

Reason:

```text
The audio is already French.
A French forced subtitle usually only displays a few specific parts.
If the forced subtitle does not exist, selecting the full French subtitle is not equivalent.
```

Result:

```text
Target episode:
Audio: French
Subtitles: None
```

## 7. Missing regular subtitle

If the user selects a regular subtitle on the reference episode, but that subtitle does not exist on the target episode, PAL should not aggressively disable the existing subtitle selection.

Example:

```text
Reference:
Audio: Japanese
Subtitles: French regular

Target:
Audio: Japanese
Subtitles: English
```

Expected behavior:

```text
PAL does not find a matching French regular subtitle.
PAL keeps the target episode current subtitle state unchanged.
```

This avoids clearing an existing selection when there is no clear equivalent subtitle available.

## Summary of added rules

```text
1. If the reference episode has no subtitle streams available:
   → do not propagate "None".

2. If the reference audio is missing on the target episode
   AND a subtitle is selected on the reference:
   → do not directly apply that subtitle.

3. If the reference audio is missing on the target episode
   AND the reference has no subtitle selected:
   → look for a regular subtitle matching the reference audio language.

4. If the reference has only one audio stream
   AND the target has multiple audio streams:
   → do not modify the target audio.
   → allow subtitle changes only if the target is already using the same audio language.

5. If a forced subtitle is selected:
   → use the forced subtitle if available.

6. If a forced subtitle is selected but missing on the target:
   → if audio and subtitle are in different languages, fall back to a regular subtitle in the same subtitle language.
   → if audio and subtitle are in the same language, disable subtitles.

7. If a regular subtitle is selected but missing on the target:
   → do not disable the existing subtitles.
```

## Validation examples

### Example 1

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: Japanese
Subtitles: French
```

Action:

```text
Episode 1 → Japanese audio + French forced subtitle
```

Expected result on episode 2:

```text
Audio: Japanese
Subtitles: French
```

Reason:

```text
Japanese audio exists on episode 2.
The French forced subtitle does not exist.
Since Japanese audio != French subtitle, PAL uses the regular French subtitle as a fallback.
```

### Example 2

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: French
Subtitles: French
```

Action:

```text
Episode 1 → French audio + French forced subtitle
```

Expected result on episode 2:

```text
Audio: French
Subtitles: None
```

Reason:

```text
The French forced subtitle does not exist on episode 2.
Since French audio == French subtitle, PAL should not select the full French subtitle instead.
```

### Example 3

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: Japanese
Subtitles: French
```

Action:

```text
Episode 1 → French audio + no subtitle
```

Expected result on episode 2:

```text
Audio: Japanese
Subtitles: French
```

Reason:

```text
French audio does not exist on episode 2.
The reference has no subtitle selected.
PAL therefore uses a regular French subtitle as fallback.
```

### Example 4

```text
Episode 1:
Audio: French, Japanese
Subtitles: French forced, French

Episode 2:
Audio: Japanese
Subtitles: French
```

Action:

```text
Episode 2 → Japanese audio + French subtitle
```

Expected result on episode 1:

```text
Episode 1 audio should not be changed automatically.
Subtitles should only be modified if episode 1 is already using Japanese audio.
```

Reason:

```text
Episode 2 has only one audio stream.
That stream does not necessarily represent an explicit user choice.
```

## Known limitations

This change does not attempt to fix incorrect file metadata.

PAL still depends on the information exposed by Plex:

```text
languageCode
forced
hearingImpaired
title
displayTitle
extendedDisplayTitle
codec
```

If two tracks are incorrectly tagged, have no distinctive name, or use different language codes despite visually appearing as the same language, PAL may still not select the expected track.

Examples of cases not covered:

```text
- "fr" on one episode and "fre" on another.
- forced subtitle not tagged as forced and without the word "forced" in its title.
- multiple subtitle tracks in the same language without distinctive titles.
- SDH / hearing impaired subtitles incorrectly tagged.
```

In these cases, the issue is more likely caused by file metadata or by what Plex exposes through its API.

## Goal of this PR

This PR aims to make track propagation safer and closer to Plex’s natural behavior when episodes of the same show do not expose exactly the same audio and subtitle streams.

It mainly avoids:

```text
- disabling useful subtitles when a natural fallback exists;
- applying a subtitle that belongs to an unavailable audio stream;
- too aggressively propagating a selection from an episode with only one audio stream;
- replacing a missing forced subtitle with a full subtitle when the audio is already in the same language.
```
