### PR TITLE
fix(cache): stream library refresh instead of loading every episode at once

### DIFF
--- a/plex_auto_languages/plex_server.py
+++ b/plex_auto_languages/plex_server.py
@@ -5,7 +5,7 @@ import warnings
 import re
 import concurrent.futures
 from urllib.parse import urlparse
-from typing import Union, Callable, List, Tuple, Optional
+from typing import Union, Callable, Iterator, List, Tuple, Optional
 from datetime import datetime, timedelta
 from requests import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import InsecureRequestWarning
@@ -155,24 +155,69 @@ class UnprivilegedPlexServer():
         except NotFound:
             return None
 
+    def iter_episodes(self, page_size: int = 1000) -> Iterator[Episode]:
+        """
+        Iterate over all episodes from non-ignored libraries, one page at a time.
+
+        Each page is released once consumed, so peak memory stays flat regardless
+        of library size. Prefer this over :meth:`episodes` when episodes are
+        consumed one at a time, as that method holds the whole library at once.
+
+        Args:
+            page_size (int): Number of episodes to request per page.
+
+        Yields:
+            Episode: Episodes from non-ignored Plex libraries.
+        """
+        if hasattr(self, 'should_ignore_library'):
+            # For PlexServer instances that have the should_ignore_library method
+            sections = self.get_show_sections()
+        else:
+            # For UnprivilegedPlexServer instances or fallback. Episodes only ever
+            # live in show sections, so this covers the same items as the previous
+            # library-wide query without requesting the whole library at once.
+            sections = [s for s in self._plex.library.sections() if isinstance(s, ShowSection)]
+
+        for section in sections:
+            container_start = 0
+            while True:
+                # `maxresults` is required, not redundant: without it fetchItems()
+                # paginates internally up to the section's total size and returns
+                # the whole thing in one list, which is the behaviour this method
+                # exists to avoid. Capping it to one page keeps this loop in charge.
+                # Sorting by addedAt keeps episodes imported mid-scan after the
+                # cursor, so they are picked up at the tail rather than shifting
+                # the offsets of pages that have not been read yet.
+                page = section.search(
+                    libtype="episode",
+                    sort="addedAt:asc",
+                    container_start=container_start,
+                    container_size=page_size,
+                    maxresults=page_size
+                )
+                if not page:
+                    break
+                yield from page
+                # Advance by what was actually returned rather than by page_size:
+                # a short page mid-section would otherwise leave a permanent gap,
+                # and a skipped episode is not harmless here. It gets evicted from
+                # episode_parts, so the next refresh sees it as newly added and
+                # re-applies the show's track selection over every user's manual
+                # choice.
+                container_start += len(page)
+
     def episodes(self) -> List[Episode]:
         """
         Get all episodes from non-ignored libraries in the Plex server.
 
+        Note:
+            This holds every episode in memory at once. Prefer :meth:`iter_episodes`
+            when the episodes can be consumed one at a time.
+
         Returns:
             List[Episode]: A list of all episodes in non-ignored Plex libraries.
         """
-        if hasattr(self, 'should_ignore_library'):
-            # For PlexServer instances that have the should_ignore_library method
-            non_ignored_sections = self.get_show_sections()
-            episodes = []
-            for section in non_ignored_sections:
-                section_episodes = section.all(libtype="episode", container_size=1000)
-                episodes.extend(section_episodes)
-            return episodes
-        else:
-            # For UnprivilegedPlexServer instances or fallback
-            return self._plex.library.all(libtype="episode", container_size=1000)
+        return list(self.iter_episodes())
 
     def get_recently_added_episodes(self, minutes: int) -> List[Episode]:
         """

--- a/plex_auto_languages/plex_server_cache.py
+++ b/plex_auto_languages/plex_server_cache.py
@@ -418,6 +418,11 @@ class PlexServerCache:
         Updates the episode_parts dictionary with current data from the Plex server.
         Identifies episodes that have been added or updated since the last refresh.
 
+        On a cold cache there is nothing to diff against, so no changes are collected
+        and both returned lists are empty. The only caller in that situation discards
+        the return value anyway, and collecting would mean retaining every Episode in
+        the library to report the whole thing as "added".
+
         Returns:
             tuple[list, list]: A tuple containing two lists:
                 - List of newly added episodes
@@ -434,11 +439,20 @@ class PlexServerCache:
                 added = []
                 updated = []
                 new_episode_parts = {}
+                # A cold cache diffs against nothing, so every episode would land in
+                # `added` and be retained for a result the caller throws away.
+                collect_changes = bool(self.episode_parts)
 
-                for episode in self._plex.episodes():
+                # Iterate lazily: holding the whole library at once costs >1GB on
+                # large libraries, which is enough to get the process OOM-killed
+                # before the refresh completes.
+                for episode in self._plex.iter_episodes():
                     part_list = new_episode_parts.setdefault(episode.key, [])
                     for part in episode.iterParts():
                         part_list.append(part.key)
+
+                    if not collect_changes:
+                        continue
 
                     if episode.key in self.episode_parts and set(self.episode_parts[episode.key]) != set(part_list):
                         updated.append(episode)


### PR DESCRIPTION
`refresh_library_cache()` loads the entire library into memory before it starts iterating, so peak memory scales with library size. On my server (65,906 episodes after ignores) that's enough to get the process OOM-killed before the refresh finishes, and since `refresh_library_on_scan` defaults to true, every Plex scan starts it again. I ended up at 40 OOM kills in one day and a RestartCount of 228.

I spent a while assuming this was just my memory limit being too low. Bumped 512M to 1G, and it died at 1G too:

```
[Wed Jul 15 13:54:35 2026] Memory cgroup out of memory: Killed process 3794228 (python)
    total-vm:651508kB, anon-rss:518240kB          <- 512M limit
[Wed Jul 15 16:03:55 2026] Memory cgroup out of memory: Killed process 3866010 (python)
    total-vm:1130496kB, anon-rss:1044976kB        <- 1G limit
    oom-kill:constraint=CONSTRAINT_MEMCG ... task=python
```

It took me embarrassingly long to even confirm these were OOMs. Docker reported `OOMKilled: false`, the healthcheck stayed green the whole time, and `docker stats` showed 19% because I kept sampling minutes after a restart, when it sits flat at ~116M. The kills are only visible in the host's dmesg (I'm on a nested LXC, so the container's own cgroup counters read clean). I also burned time on the `AttributeError: 'NoneType' object has no attribute 'replace'` in plexapi's `Episode.__repr__` that shows up in my logs. That one's real but separate, and it isn't what's killing the process.

The cause is `episodes()`. `section.all(libtype="episode", container_size=1000)` already pages the HTTP requests in 1000s, but `episodes.extend(...)` accumulates every page into one list, and nothing is released until the refresh returns. That's fine on a library that fits in RAM. Mine doesn't, and there's no limit I can set that fixes it, because the list grows with the library and I just hit the new ceiling instead.

`refresh_library_cache()` only needs one episode at a time. So this adds `iter_episodes()`, which pages each show section and yields each page before requesting the next, and leaves `episodes()` as a `list(iter_episodes())` wrapper. Measured on the same 65,906-episode library, plexapi 4.18.1:

```
before:  OOM-killed at >1024MB, refresh never completed
after:   92MB peak RSS, 65,906/65,906 episodes, no duplicates, 129s
```

The 92MB is mostly the `episode_parts` dict of part-key strings, roughly 0.3KB per episode. I haven't taken a heap snapshot, so I can't claim that's 100% of what remains.

Four things in the diff that aren't obvious:

`maxresults=page_size` might look redundant next to `container_size`, but without it `fetchItems()` keeps paginating internally up to the section's total size and hands back the whole thing in one list, which is exactly what this is trying to avoid.

The cursor advances by `len(page)` and stops only on an empty page, rather than advancing by a fixed `page_size`. A short page mid-section would otherwise leave a permanent gap, and a skipped episode isn't harmless: it drops out of `episode_parts`, so the next refresh sees it as newly added and reapplies the show's track selection over whatever the user picked manually.

Results are sorted by `addedAt` so episodes imported while the scan is running land after the cursor instead of shifting the offsets of pages that haven't been read yet. The refresh runs because something was just added, so that window isn't theoretical. Offset paging can still shift on deletes; I don't think there's a fix for that short of keyset pagination, which Plex doesn't offer.

The unprivileged branch used to do a library-wide `library.all(libtype="episode")`. Episodes only live in show sections, so iterating those covers the same items. It also avoids a whole-library query that reliably times out at 30s on my server.

One related change: `refresh_library_cache()` now skips collecting `added`/`updated` when the cache is cold. There's nothing to diff against at that point, so every episode counts as "added" and gets retained to build a list that the cold-cache caller in `__init__` discards anyway.

Something I did not fix here: in the normal scan path, `added`/`updated` still hold full Episode objects. If a bulk operation changes part keys across the library (quality upgrades, a path remap, a reimport), everything lands in `updated` and you're back around 790MB on a library this size. Fixing that means collecting lightweight records and having the callers refetch, which changes the contract in `status.py` and `plex_server.py`. That's a bigger change and it'd bury this one, so I'll send it as a second PR once this is settled.

Does this approach look acceptable to you? I'm happy to rework it if you'd rather solve it a different way. There are no tests in the repo so I verified against a live server; I can share the paging-correctness check I ran (pages disjoint, no overlap, stable order across calls) if that's useful.

This may also be what's behind #39.
